### PR TITLE
Fix: Stick Prokka to use BioPerl 1.7.2

### DIFF
--- a/workflow/envs/prokka.yaml
+++ b/workflow/envs/prokka.yaml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - prokka=1.14.6
+  - perl-bioperl=1.7.2
   - ncbi-genome-download=0.3.1
   - pandas
   - biopython


### PR DESCRIPTION
- This is a quick patch to fix #108
- Prokka seems to broke on the latest BioPerl (1.7.8) 