### PR TITLE
fix: deal with collapsed LOCUS name and length

### DIFF
--- a/workflow/bgcflow/bgcflow/data/format_genbank_meta.py
+++ b/workflow/bgcflow/bgcflow/data/format_genbank_meta.py
@@ -193,11 +193,11 @@ def modify_id(accession_id, original_id, locus_index, record_counts, id_collecti
     """
     logging.info(f"{original_id}: Attempting to change locus name...")
 
-    # For genbank or refseq record, remove version from string
+    # For refseq record, remove the accession prefix (first two digits) from string
     if accession_id.startswith("GCF"):
-        logging.debug(f"{original_id}: Assuming locus came from Refseq. Removing version from locus name.")
+        logging.debug(f"{original_id}: Assuming locus came from Refseq. Removing refseq accession prefix.")
         refseq_type, refseq_number, refseq_version = re.split('_|[.]', original_id)
-        new_id = f"{refseq_type}_{refseq_number}"
+        new_id = f"{refseq_number}.{refseq_version}"
 
     elif accession_id.startswith("GCA"):
         logging.info(f"{original_id}: Assuming locus came from Genbank. Removing version from locus name...")


### PR DESCRIPTION
- This patch deal with: #107 
- Case example: `GCF_012922115.1`, where `Bio.SeqIO` fail to read the genbank file:
```
Name and length collide in the LOCUS line:
LOCUS       NZ_JABAQG010000001.110825588 bp    DNA     linear       10-FEB-2022 
```
- This PR attempt to shorten the record id, by removing version or using other means.
- Example log:
```
INFO     12/02 21:43:51   Formatting genbank file: data/interim/prokka/GCF_012922115.1/GCF_012922115.1.gbk
WARNING  12/02 21:43:51   Parsing fail: Name and length collide in the LOCUS line:
LOCUS       NZ_JABAQG010000001.110825588 bp    DNA     linear       10-FEB-2022

INFO     12/02 21:43:51   Attempting to fix genbank file...
INFO     12/02 21:43:51   Reading file as text: data/interim/prokka/GCF_012922115.1/GCF_012922115.1.gbk
DEBUG    12/02 21:43:51   Found 2 records.
INFO     12/02 21:43:51   Checking header format...
WARNING  12/02 21:43:51   Record name and length collide in the LOCUS line
INFO     12/02 21:43:51   NZ_JABAQG010000001.1: Attempting to change locus name...
DEBUG    12/02 21:43:51   NZ_JABAQG010000001.1: Assuming locus came from Refseq. Removing version from locus name.
INFO     12/02 21:43:51   NZ_JABAQG010000001.1: Making sure id is unique...
DEBUG    12/02 21:43:51   NZ_JABAQG010000001.1: shortened to NZ_JABAQG010000001
INFO     12/02 21:43:51   Writing result to: data/interim/prokka/GCF_012922115.1/GCF_012922115.1-change_log.gbk
INFO     12/02 21:43:51   Retry parsing with Bio.SeqIO...
DEBUG    12/02 21:43:51   Taxonomy found: ['Bacteria', 'Actinobacteriota', 'Actinomycetia', 'Streptomycetales', 'Streptomycetaceae', 'Streptomyces', 'Streptomyces mirabilis']
INFO     12/02 21:43:52   Formatting record 0...
INFO     12/02 21:43:52   Formatting record 1...
INFO     12/02 21:43:52   Writing final output: data/processed/genbank/GCF_012922115.1.gbk
```

It also returns the change log as json file:
```json
{
    "0": {
        "original_header": "LOCUS       NZ_JABAQG010000001.110825588 bp    DNA     linear       10-FEB-2022\n",
        "length": "10825588",
        "original_id": "NZ_JABAQG010000001.1",
        "accept_format": false,
        "new_id": "NZ_JABAQG010000001",
        "new_header": "LOCUS       NZ_JABAQG010000001  10825588 bp    DNA     linear       10-FEB-2022\n"
    },
    "1": {
        "original_header": "LOCUS       NZ_JABAQG010000002.1   67358 bp    DNA     linear       10-FEB-2022\n",
        "length": "67358",
        "original_id": "NZ_JABAQG010000002.1",
        "accept_format": true
    }
}
```

Example result:
```
LOCUS       NZ_JABAQG010000001  10825588 bp    DNA     linear   UNK 10-FEB-2022
DEFINITION  Streptomyces sp. strain RLA2-12.
ACCESSION   NZ_JABAQG010000001
VERSION     NZ_JABAQG010000001
KEYWORDS    .
SOURCE      Streptomyces sp
  ORGANISM  Streptomyces sp.
            Bacteria; Actinobacteriota; Actinomycetia; Streptomycetales;
            Streptomycetaceae; Streptomyces; Streptomyces mirabilis.
COMMENT     Annotated using prokka 1.14.6 from
            https://github.com/tseemann/prokka.
            ##BGCflow-Data-START##
            Version      :: 0.1.0-1e4c8dd(changed)
            Run date     :: 2022-02-12 21:33:45
            Original ID  :: NZ_JABAQG010000001.1
            ##BGCflow-Data-END##
```