### PR TITLE
feat: add defense-finder subworkflow

### DIFF
--- a/workflow/defense-finder
+++ b/workflow/defense-finder
@@ -1,0 +1,28 @@
+include: "rules/common.smk"
+
+
+##### 1. Extract information from config file
+(
+    DF_PROJECTS,
+    DF_SAMPLES,
+    PROKKA_DB_TABLE,
+    PROKKA_DB_MAP,
+    PEP_PROJECTS,
+) = extract_project_information(config)
+
+##### 2. Generate wildcard constants #####
+STRAINS = DF_SAMPLES.genome_id.to_list()
+
+##### 3. Wildcard constraints #####
+wildcard_constraints:
+    strains="|".join(STRAINS),
+
+##### Target rules #####
+
+rule all:
+    input:
+        expand("data/interim/defense_finder/{strains}/", strains=STRAINS),
+
+
+##### Modules #####
+include: "rules/defense-finder.smk"

--- a/workflow/envs/defense-finder.post-deploy.sh
+++ b/workflow/envs/defense-finder.post-deploy.sh
@@ -1,0 +1,1 @@
+defense-finder update

--- a/workflow/envs/defense-finder.yaml
+++ b/workflow/envs/defense-finder.yaml
@@ -1,0 +1,8 @@
+name: defense-finder
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pip
+  - pip:
+    - mdmparis-defense-finder==1.2.0

--- a/workflow/rules/defense-finder.smk
+++ b/workflow/rules/defense-finder.smk
@@ -1,0 +1,14 @@
+rule defense_finder:
+    input:
+        faa="data/interim/prokka/{strains}/{strains}.faa",
+    output:
+        defense_finder=directory("data/interim/defense_finder/{strains}/"),
+    conda:
+        "../envs/defense-finder.yaml"
+    threads: 4
+    log:
+        "logs/defense-finder/defense-finder/defense-finder-{strains}.log",
+    shell:
+        """
+        defense-finder run -w {threads} {input.faa} -o {output.defense_finder} &>> {log}
+        """


### PR DESCRIPTION
Hi @ChMaWh, here is the first draft of `defense-finder` subworkflow:

## Usage:
1. Create a conda environment and install the [`BGCFlow` python wrapper](https://github.com/NBChub/bgcflow_wrapper) :

```bash
# create and activate a new conda environment
conda create -n bgcflow -c conda-forge python=3.11 pip openjdk -y
conda activate bgcflow

# install `BGCFlow` wrapper
pip install git+https://github.com/NBChub/bgcflow_wrapper.git

# make sure to use bgcflow_wrapper version >= 0.2.7
bgcflow --version
```

2. Deploy and test-run BGCFlow, change `your_bgcflow_directory` variable accordingly:
```bash
# Deploy and run BGCFlow
bgcflow clone <your_bgcflow_directory> # clone `BGCFlow` to your_bgcflow_directory
cd <your_bgcflow_directory> # move to BGCFLOW_PATH
bgcflow init # initiate `BGCFlow` config and examples from template
bgcflow run -n # do a dry run, remove the flag "-n" to run the example dataset
```

3. Checkout to `defense-finder` branch:

```bash
git checkout defense-finder
bgcflow run --workflow workflow/defense-finder -n
```

4. To run it, remove the `-n` flag, and maybe define the number or cores to use:
```bash
bgcflow run --workflow workflow/defense-finder -c 8 #adjust the number of cores to use
```

5. Right now, the output is still located in `data/interim/defense-finder`