### PR TITLE
Issue #369: Fix file path for rule dictionary loading

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -728,7 +728,7 @@ def get_project_outputs(
     Returns:
         final_output {list} -- list of final output files
     """
-    with open(workflow.source_path(f"../../{rule_dict_path}"), "r") as file:
+    with open(workflow.source_path(f"../{rule_dict_path}"), "r") as file:
         rule_dict = yaml.safe_load(file)
 
     selection = [


### PR DESCRIPTION
Updated file path in common.smk for rule dictionary.

Possible issue with file path in bgcflow\workflow\rules\common.smk #369